### PR TITLE
chore: Remove `app_max_map_size` from sample configuration.

### DIFF
--- a/client-samples/ingest-python-sample/dozer-config.yaml
+++ b/client-samples/ingest-python-sample/dozer-config.yaml
@@ -7,7 +7,6 @@ connections:
     name: trips_arrow
 
 cache_max_map_size: 1073741824
-app_max_map_size: 1073741824
 
 api:
   rest:

--- a/sql/window-functions/dozer-config.yaml
+++ b/sql/window-functions/dozer-config.yaml
@@ -38,4 +38,3 @@ endpoints:
       primary_key: 
 
 cache_max_map_size: 2147483648
-app_max_map_size: 2147483648


### PR DESCRIPTION
Don't merge until https://github.com/getdozer/dozer/pull/1319 is released.