### PR TITLE
Changed default ports for the Kafka Sample

### DIFF
--- a/connectors/kafka/docker-compose.yml
+++ b/connectors/kafka/docker-compose.yml
@@ -1,6 +1,4 @@
----
 version: "3.7"
-name: redpanda-quickstart
 networks:
   redpanda_network:
     driver: bridge
@@ -64,6 +62,6 @@ services:
             enabled: true
             urls: ["http://redpanda-0:9644"]
     ports:
-      - 8080:8080
+      - 61234:61234
     depends_on:
       - redpanda-0

--- a/connectors/kafka/docker-compose.yml
+++ b/connectors/kafka/docker-compose.yml
@@ -1,4 +1,5 @@
 version: "3.7"
+name: redpanda-quickstart
 networks:
   redpanda_network:
     driver: bridge
@@ -62,6 +63,6 @@ services:
             enabled: true
             urls: ["http://redpanda-0:9644"]
     ports:
-      - 61234:61234
+      - 8080:8080
     depends_on:
       - redpanda-0

--- a/connectors/kafka/dozer-config.yaml
+++ b/connectors/kafka/dozer-config.yaml
@@ -1,16 +1,15 @@
 app_name: kafka-transactions
-cache_max_map_size: 8589934592
-api:
-  internal:
-    port: 50052
-    host: "[::1]"
-  rest:
-    port: 8088
+
 connections:
   - config : !Kafka
       broker: localhost:19092
       schema_registry_url: http://localhost:18081
     name: kafka_store
+
+sources:
+  - name: transactions
+    table_name: transactions
+    connection: kafka_store
 
 sql: |
   SELECT
@@ -22,15 +21,7 @@ sql: |
   INTO tout
   FROM transactions t;
 
-sources:
-  - name: transactions
-    table_name: transactions
-    connection: kafka_store
-
 endpoints:
   - name: tout
     path: /tout
     table_name: tout
-
-telemetry:
-  metrics: !Prometheus

--- a/connectors/kafka/dozer-config.yaml
+++ b/connectors/kafka/dozer-config.yaml
@@ -1,5 +1,5 @@
 app_name: kafka-transactions
-
+cache_max_map_size: 8589934592
 connections:
   - config : !Kafka
       broker: localhost:19092
@@ -25,3 +25,6 @@ endpoints:
   - name: tout
     path: /tout
     table_name: tout
+
+telemetry:
+  metrics: !Prometheus


### PR DESCRIPTION
The sample would crash on running with `dozer live`. Since the port 8080 was pre-occupied with RedPanda Server.

Changes:
1. `docker-compose.yml`: Start the RedPanda server on port 61234 instead of 8080.
2. `dozer-config.yaml`: Keep the Rest port default to 8080 instead of 8088.